### PR TITLE
[feat] 허브 도메인 CRUD 및 soft Delete 구현

### DIFF
--- a/src/main/java/com/logilink/hub/common/exception/HubErrorCode.java
+++ b/src/main/java/com/logilink/hub/common/exception/HubErrorCode.java
@@ -1,0 +1,23 @@
+package com.logilink.hub.common.exception;
+
+import com.sparta.logilinkcommon.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum HubErrorCode implements ErrorCode {
+
+    HUB_NOT_FOUND("HUB0001", "해당 허브를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    HUB_NAME_DUPLICATE("HUB002", "이미 사용 중인 허브 이름입니다.", HttpStatus.CONFLICT),
+    HUB_ROUTE_NOT_FOUND("HUB003", "해당 허브 이동 경로를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+
+    HubErrorCode(String code, String message, HttpStatus status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/logilink/hub/domain/hub/controller/HubController.java
+++ b/src/main/java/com/logilink/hub/domain/hub/controller/HubController.java
@@ -1,0 +1,56 @@
+package com.logilink.hub.domain.hub.controller;
+
+import com.logilink.hub.domain.hub.model.dto.request.HubCreateRequest;
+import com.logilink.hub.domain.hub.model.dto.request.HubUpdateRequest;
+import com.logilink.hub.domain.hub.model.dto.response.HubResponse;
+import com.logilink.hub.domain.hub.model.entity.Hub;
+import com.logilink.hub.domain.hub.repository.HubRepository;
+import com.logilink.hub.domain.hub.service.HubService;
+import com.logilink.hub.domain.hub.service.HubServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/hubs")
+@RequiredArgsConstructor
+public class HubController {
+
+    private final HubService hubService;
+
+    @PostMapping
+    public ResponseEntity<HubResponse> createHub(@RequestBody HubCreateRequest hubCreateRequest) {
+        Hub hub = hubService.createHub(hubCreateRequest.toEntity());
+        return ResponseEntity.ok(new HubResponse(hub));
+    }
+
+    @PutMapping("/{hubId}")
+    public ResponseEntity<HubResponse> updateHub(@PathVariable UUID hubId, @RequestBody HubUpdateRequest hubUpdateRequest) {
+        Hub hub = hubService.updateHub(hubId, hubUpdateRequest.toEntity());
+        return ResponseEntity.ok(new HubResponse(hub));
+    }
+
+    @DeleteMapping("/{hubId}")
+    public ResponseEntity<Void> deleteHub(@PathVariable UUID hubId) {
+        hubService.deleteHub(hubId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{hubId}")
+    public ResponseEntity<HubResponse> getHub(@PathVariable UUID hubId) {
+        Hub hub = hubService.getHub(hubId);
+        return ResponseEntity.ok(new HubResponse(hub));
+    }
+
+    public ResponseEntity<List<HubResponse>> getAllHubs() {
+        List<HubResponse> hubs = hubService.getAllHubs()
+                .stream()
+                .map(HubResponse::new)
+                .toList();
+        return ResponseEntity.ok(hubs);
+    }
+
+}

--- a/src/main/java/com/logilink/hub/domain/hub/model/dto/request/HubCreateRequest.java
+++ b/src/main/java/com/logilink/hub/domain/hub/model/dto/request/HubCreateRequest.java
@@ -1,0 +1,28 @@
+package com.logilink.hub.domain.hub.model.dto.request;
+
+import com.logilink.hub.domain.hub.model.entity.Hub;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class HubCreateRequest {
+
+    @NotBlank(message = "허브 이름은 필수입니다.")
+    private String name;
+
+    @NotBlank(message = "허브 주소는 필수입니다.")
+    private String address;
+
+    private Double latitude;
+    private Double longitude;
+
+    public Hub toEntity() {
+        return Hub.builder()
+                .name(name)
+                .address(address)
+                .latitude(latitude)
+                .longitude(longitude).build();
+    }
+}

--- a/src/main/java/com/logilink/hub/domain/hub/model/dto/request/HubUpdateRequest.java
+++ b/src/main/java/com/logilink/hub/domain/hub/model/dto/request/HubUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.logilink.hub.domain.hub.model.dto.request;
+
+import com.logilink.hub.domain.hub.model.entity.Hub;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class HubUpdateRequest {
+
+    private String name;
+    private String address;
+    private Double latitude;
+    private Double longitude;
+
+    public Hub toEntity() {
+        return Hub.builder()
+                .name(name)
+                .address(address)
+                .latitude(latitude)
+                .longitude(longitude).build();
+    }
+}

--- a/src/main/java/com/logilink/hub/domain/hub/model/dto/response/HubResponse.java
+++ b/src/main/java/com/logilink/hub/domain/hub/model/dto/response/HubResponse.java
@@ -1,0 +1,27 @@
+package com.logilink.hub.domain.hub.model.dto.response;
+
+import com.logilink.hub.domain.hub.model.entity.Hub;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class HubResponse {
+
+    private UUID hubId;
+    private String name;
+    private String address;
+    private Double latitude;
+    private Double longitude;
+    private LocalDateTime createdAt;
+
+    public HubResponse(Hub hub) {
+        this.hubId = hub.getId();
+        this.name = hub.getName();
+        this.address = hub.getAddress();
+        this.latitude = hub.getLatitude();
+        this.longitude = hub.getLongitude();
+        this.createdAt = hub.getCreatedAt();
+    }
+}

--- a/src/main/java/com/logilink/hub/domain/hub/model/entity/Hub.java
+++ b/src/main/java/com/logilink/hub/domain/hub/model/entity/Hub.java
@@ -1,0 +1,49 @@
+package com.logilink.hub.domain.hub.model.entity;
+
+import com.sparta.logilinkcommon.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_hubs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Hub extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    @Column(name = "hub_id", updatable = false, nullable = false, columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(name = "hub_name", length = 100, nullable = false, unique = true)
+    private String name;
+
+    @Column(name = "hub_address", length = 255, nullable = false)
+    private String address;
+
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
+
+    public void update(Hub updatedHub) {
+        this.name = updatedHub.getName();
+        this.address = updatedHub.getAddress();
+        this.latitude = updatedHub.getLatitude();
+        this.longitude = updatedHub.getLongitude();
+    }
+
+    public void delete(Long userId) {
+        softDelete(userId);
+    }
+
+
+}

--- a/src/main/java/com/logilink/hub/domain/hub/repository/HubRepository.java
+++ b/src/main/java/com/logilink/hub/domain/hub/repository/HubRepository.java
@@ -1,0 +1,21 @@
+package com.logilink.hub.domain.hub.repository;
+
+import com.logilink.hub.domain.hub.model.entity.Hub;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface HubRepository extends JpaRepository<Hub, UUID> {
+
+    // 삭제 안 된 허브만 조회
+    List<Hub> findAllByDeletedAtIsNull();
+
+    // 허브 이름 중복 검사
+    boolean existsByName(String name);
+
+    // 삭제 안 된 허브 단건 조회
+    Optional<Hub> findByIdAndDeletedAtIsNull(UUID hubId);
+
+}

--- a/src/main/java/com/logilink/hub/domain/hub/service/HubService.java
+++ b/src/main/java/com/logilink/hub/domain/hub/service/HubService.java
@@ -1,0 +1,14 @@
+package com.logilink.hub.domain.hub.service;
+
+import com.logilink.hub.domain.hub.model.entity.Hub;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface HubService {
+    Hub createHub(Hub hub);
+    Hub updateHub(UUID hubId, Hub updatedHub);
+    void deleteHub(UUID hubId);
+    Hub getHub(UUID hubId);
+    List<Hub> getAllHubs();
+}

--- a/src/main/java/com/logilink/hub/domain/hub/service/HubServiceImpl.java
+++ b/src/main/java/com/logilink/hub/domain/hub/service/HubServiceImpl.java
@@ -1,0 +1,51 @@
+package com.logilink.hub.domain.hub.service;
+
+import com.logilink.hub.common.exception.HubErrorCode;
+import com.logilink.hub.domain.hub.model.entity.Hub;
+import com.logilink.hub.domain.hub.repository.HubRepository;
+import com.sparta.logilinkcommon.common.exception.AppException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HubServiceImpl implements HubService {
+
+    private final HubRepository hubRepository;
+
+    @Override
+    @Transactional
+    public Hub createHub(Hub hub) {
+        return hubRepository.save(hub);
+    }
+
+    @Override
+    public Hub updateHub(UUID hubId, Hub updatedHub) {
+        Hub existingHub = hubRepository.findByIdAndDeletedAtIsNull(hubId).orElseThrow(() -> AppException.of(HubErrorCode.HUB_NOT_FOUND));
+        existingHub.update(updatedHub);
+        return hubRepository.save(existingHub);
+    }
+
+    @Override
+    public void deleteHub(UUID hubId) {
+        Hub hub = hubRepository.findByIdAndDeletedAtIsNull(hubId).orElseThrow(() -> AppException.of(HubErrorCode.HUB_NOT_FOUND));
+        hub.delete(1L); // 추후 실제 로그인 유저 ID로 대체
+
+    }
+
+    @Override
+    public Hub getHub(UUID hubId) {
+        return hubRepository.findById(hubId).orElseThrow(() -> AppException.of(HubErrorCode.HUB_NOT_FOUND));
+    }
+
+    @Override
+    public List<Hub> getAllHubs() {
+        return hubRepository.findAllByDeletedAtIsNull();
+    }
+
+}


### PR DESCRIPTION
#1

### 변경사항
- 허브 엔티티 생성 및 기본 필드 정의
- 허브 레포지토리 생성 및 soft-delete 적용
- 허브 서비스 로직 및 예외 코드 적용 추가
- 허브 DTO 및 컨트롤러 CRUD 뼈대 구현

### 리뷰요청
- BaseTimeEntity에 softDelete() 추가 후 반영 예정
- soft-delete 처리 로직 확인 부탁드립니다.
